### PR TITLE
feat: add Docker multi-arch image builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,6 +43,46 @@ sboms:
   - id: archive
     artifacts: archive
 
+# Docker configuration
+dockers:
+  - id: amd64
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "{{ .ProjectName }}:latest-amd64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+    skip_push: true
+  - id: arm64
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "{{ .ProjectName }}:latest-arm64"
+    dockerfile: Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64/v8"
+    skip_push: true
+
+# Docker manifest configuration
+docker_manifests:
+  - name_template: "{{ .ProjectName }}:{{ .Version }}"
+    image_templates:
+      - "{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "{{ .ProjectName }}:{{ .Version }}-arm64"
+    skip_push: true
+  - name_template: "{{ .ProjectName }}:latest"
+    image_templates:
+      - "{{ .ProjectName }}:latest-amd64"
+      - "{{ .ProjectName }}:latest-arm64"
+    skip_push: true
+
 # Changelog configuration
 changelog:
   use: github

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+
+COPY lazycfg /usr/local/bin/lazycfg
+
+ENTRYPOINT ["/usr/local/bin/lazycfg"]


### PR DESCRIPTION
## Summary

Implements Docker multi-architecture image builds for the lazycfg CLI tool to make it portable across different platforms.

## Changes

- Created Alpine-based Dockerfile for minimal CLI container image
- Configured GoReleaser to build Docker images for linux/amd64 and linux/arm64 architectures
- Added Docker manifest configuration to support multi-arch images
- Configured builds to run locally without pushing to registry (skip_push: true)

## Testing

Verified the configuration by:
- Running `goreleaser check` to validate configuration
- Building images with `goreleaser release --snapshot --clean --skip=publish,sbom`
- Testing both amd64 and arm64 images with `docker run --rm lazycfg:latest-{arch} --version`
- Confirming all project tests pass with `task check`

## References

Resolves lazycfg-5un