### PR TITLE
test: expand kubernetes provider test coverage

### DIFF
--- a/internal/providers/kubernetes/eks_discovery_test.go
+++ b/internal/providers/kubernetes/eks_discovery_test.go
@@ -178,3 +178,343 @@ func TestResolveProfilesExplicit(t *testing.T) {
 		t.Fatalf("profiles = %v", profiles)
 	}
 }
+
+func TestNormalizeRegions(t *testing.T) {
+	tests := []struct {
+		name     string
+		regions  []string
+		expected []string
+		wantErr  bool
+	}{
+		{
+			name:    "nil regions",
+			regions: nil,
+			wantErr: true,
+		},
+		{
+			name:    "empty regions",
+			regions: []string{},
+			wantErr: true,
+		},
+		{
+			name:    "only whitespace regions",
+			regions: []string{"  ", "", "   "},
+			wantErr: true,
+		},
+		{
+			name:     "valid regions",
+			regions:  []string{"us-east-1", "us-west-2"},
+			expected: []string{"us-east-1", "us-west-2"},
+			wantErr:  false,
+		},
+		{
+			name:     "regions with whitespace",
+			regions:  []string{" us-east-1 ", "us-west-2"},
+			expected: []string{"us-east-1", "us-west-2"},
+			wantErr:  false,
+		},
+		{
+			name:     "duplicate regions",
+			regions:  []string{"us-east-1", "us-east-1", "us-west-2"},
+			expected: []string{"us-east-1", "us-west-2"},
+			wantErr:  false,
+		},
+		{
+			name:     "regions with empty entries",
+			regions:  []string{"us-east-1", "", "us-west-2"},
+			expected: []string{"us-east-1", "us-west-2"},
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := normalizeRegions(tt.regions)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("normalizeRegions(%v) = %v, want %v", tt.regions, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDecodeClusterCA(t *testing.T) {
+	tests := []struct {
+		name     string
+		ca       *types.Certificate
+		expected []byte
+		wantErr  bool
+	}{
+		{
+			name:     "nil certificate",
+			ca:       nil,
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name:     "nil data",
+			ca:       &types.Certificate{Data: nil},
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name: "empty data",
+			ca: &types.Certificate{Data: func() *string {
+				s := ""
+				return &s
+			}()},
+			expected: nil,
+			wantErr:  false,
+		},
+		{
+			name: "valid base64",
+			ca: &types.Certificate{Data: func() *string {
+				s := "dGVzdA=="
+				return &s
+			}()},
+			expected: []byte("test"),
+			wantErr:  false,
+		},
+		{
+			name: "invalid base64",
+			ca: &types.Certificate{Data: func() *string {
+				s := "not-valid-base64!!!"
+				return &s
+			}()},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := decodeClusterCA(tt.ca)
+			if tt.wantErr && err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !tt.wantErr && !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("decodeClusterCA() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDescribeClusterErrors(t *testing.T) {
+	ctx := context.Background()
+	timeout := 100 * time.Millisecond
+
+	t.Run("describe error", func(t *testing.T) {
+		client := &mockEKSClient{
+			describeErr: errors.New("describe failed"),
+		}
+
+		_, err := describeCluster(ctx, client, timeout, "profile", "region", "cluster")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("nil cluster in response", func(t *testing.T) {
+		client := &mockEKSClient{
+			outputs: map[string]*eks.DescribeClusterOutput{
+				"cluster": {Cluster: nil},
+			},
+		}
+
+		_, err := describeCluster(ctx, client, timeout, "profile", "region", "cluster")
+		if err == nil {
+			t.Fatal("expected error for nil cluster, got nil")
+		}
+	})
+
+	t.Run("missing endpoint", func(t *testing.T) {
+		name := "cluster"
+		client := &mockEKSClient{
+			outputs: map[string]*eks.DescribeClusterOutput{
+				name: {
+					Cluster: &types.Cluster{
+						Name:     &name,
+						Endpoint: nil,
+					},
+				},
+			},
+		}
+
+		_, err := describeCluster(ctx, client, timeout, "profile", "region", name)
+		if err == nil {
+			t.Fatal("expected error for missing endpoint, got nil")
+		}
+	})
+}
+
+func TestDiscoverEKSClustersNilConfig(t *testing.T) {
+	_, err := DiscoverEKSClusters(context.Background(), nil, nil)
+	if err == nil {
+		t.Fatal("expected error for nil config, got nil")
+	}
+}
+
+func TestDiscoverEKSClustersListError(t *testing.T) {
+	tmpDir := t.TempDir()
+	credentialsData, err := readFixture("credentials_valid")
+	if err != nil {
+		t.Fatalf("readFixture failed: %v", err)
+	}
+	credentialsPath := filepath.Join(tmpDir, "credentials")
+	if err := writeFixture(credentialsPath, string(credentialsData)); err != nil {
+		t.Fatalf("writeFixture failed: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.AWS.CredentialsFile = credentialsPath
+	cfg.AWS.Profiles = []string{"test"}
+	cfg.AWS.Regions = []string{"us-west-2"}
+	cfg.AWS.Timeout = 100 * time.Millisecond
+
+	factory := func(_ context.Context, _, _ string) (EKSClient, error) {
+		return &mockEKSClient{
+			listErr: errors.New("list failed"),
+		}, nil
+	}
+
+	_, err = DiscoverEKSClusters(context.Background(), cfg, factory)
+	if err == nil {
+		t.Fatal("expected error for list failure, got nil")
+	}
+}
+
+func TestDiscoverEKSClustersFactoryError(t *testing.T) {
+	tmpDir := t.TempDir()
+	credentialsData, err := readFixture("credentials_valid")
+	if err != nil {
+		t.Fatalf("readFixture failed: %v", err)
+	}
+	credentialsPath := filepath.Join(tmpDir, "credentials")
+	if err := writeFixture(credentialsPath, string(credentialsData)); err != nil {
+		t.Fatalf("writeFixture failed: %v", err)
+	}
+
+	cfg := DefaultConfig()
+	cfg.AWS.CredentialsFile = credentialsPath
+	cfg.AWS.Profiles = []string{"test"}
+	cfg.AWS.Regions = []string{"us-west-2"}
+	cfg.AWS.Timeout = 100 * time.Millisecond
+
+	factory := func(_ context.Context, _, _ string) (EKSClient, error) {
+		return nil, errors.New("factory error")
+	}
+
+	_, err = DiscoverEKSClusters(context.Background(), cfg, factory)
+	if err == nil {
+		t.Fatal("expected error for factory failure, got nil")
+	}
+}
+
+func TestSortClusters(t *testing.T) {
+	clusters := []DiscoveredCluster{
+		{Profile: "b", Region: "us-west-2", Name: "cluster1"},
+		{Profile: "a", Region: "us-east-1", Name: "cluster2"},
+		{Profile: "a", Region: "us-east-1", Name: "cluster1"},
+		{Profile: "a", Region: "us-west-2", Name: "cluster1"},
+	}
+
+	sortClusters(clusters)
+
+	expected := []DiscoveredCluster{
+		{Profile: "a", Region: "us-east-1", Name: "cluster1"},
+		{Profile: "a", Region: "us-east-1", Name: "cluster2"},
+		{Profile: "a", Region: "us-west-2", Name: "cluster1"},
+		{Profile: "b", Region: "us-west-2", Name: "cluster1"},
+	}
+
+	if !reflect.DeepEqual(clusters, expected) {
+		t.Errorf("sortClusters did not produce expected order: got %+v", clusters)
+	}
+}
+
+func TestParseCredentialProfiles(t *testing.T) {
+	t.Run("empty credentials file path", func(t *testing.T) {
+		_, err := parseCredentialProfiles("")
+		if err == nil {
+			t.Fatal("expected error for empty path, got nil")
+		}
+	})
+
+	t.Run("whitespace credentials file path", func(t *testing.T) {
+		_, err := parseCredentialProfiles("   ")
+		if err == nil {
+			t.Fatal("expected error for whitespace path, got nil")
+		}
+	})
+
+	t.Run("credentials with comments", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		credentialsPath := filepath.Join(tmpDir, "credentials")
+		content := `# Comment line
+[default]
+aws_access_key_id = default
+
+; Another comment
+[prod]
+aws_access_key_id = prod
+`
+		if err := writeFixture(credentialsPath, content); err != nil {
+			t.Fatalf("writeFixture failed: %v", err)
+		}
+
+		profiles, err := parseCredentialProfiles(credentialsPath)
+		if err != nil {
+			t.Fatalf("parseCredentialProfiles failed: %v", err)
+		}
+
+		expected := []string{"default", "prod"}
+		if !reflect.DeepEqual(profiles, expected) {
+			t.Errorf("profiles = %v, want %v", profiles, expected)
+		}
+	})
+}
+
+func TestNormalizeProfiles(t *testing.T) {
+	tests := []struct {
+		name     string
+		profiles []string
+		expected []string
+	}{
+		{
+			name:     "empty profiles",
+			profiles: []string{},
+			expected: []string{},
+		},
+		{
+			name:     "nil profiles",
+			profiles: nil,
+			expected: []string{},
+		},
+		{
+			name:     "profiles with whitespace",
+			profiles: []string{" prod ", "  ", "staging"},
+			expected: []string{"prod", "staging"},
+		},
+		{
+			name:     "duplicate profiles",
+			profiles: []string{"prod", "prod", "staging"},
+			expected: []string{"prod", "staging"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeProfiles(tt.profiles)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("normalizeProfiles(%v) = %v, want %v", tt.profiles, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add comprehensive tests for kubernetes provider helper functions
- Improve test coverage from ~80% to 86%
- Cover edge cases for path expansion, region normalization, and EKS discovery error handling

## Changes

**config_test.go:**
- Tests for `expandHomeDir` edge cases (empty path, absolute path, tilde variants)
- Tests for `normalizePath` error handling (empty, whitespace, relative paths)
- Tests for `ConfigFromMap` with partial overrides
- Tests for config validation in demo and merge-only modes

**eks_discovery_test.go:**
- Tests for `normalizeRegions` edge cases (nil, empty, whitespace, duplicates)
- Tests for `decodeClusterCA` error handling (nil, empty, invalid base64)
- Tests for `describeCluster` error scenarios
- Tests for `DiscoverEKSClusters` error paths (nil config, list errors, factory errors)
- Tests for `sortClusters` ordering
- Tests for `parseCredentialProfiles` edge cases
- Tests for `normalizeProfiles` handling

## Testing

All tests pass locally with `task check`.

## Related

Closes lazycfg-jky