### PR TITLE
ci: add semantic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@aeb8638f5a8dd1d6f84f1f6b2e0a7b8d4f60f223 # v4
+        with:
+          node-version: "lts/*"
+
+      - name: Setup Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Semantic Release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6
+        with:
+          semantic_version: 25
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch tags
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: git fetch --tags --force
+
+      - name: GoReleaser
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+project_name: lazycfg
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - binary: lazycfg
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .Commit }}
+      - -X main.date={{ .Date }}
+    main: ./cmd/lazycfg
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc

--- a/README.md
+++ b/README.md
@@ -162,3 +162,16 @@ OPENCODE_TIMEOUT=3600 task iterate
 8. Sync beads: `bd sync`
 9. Create pull request: `gh pr create --title "feat: your feature" --body "Description"`
 10. Address review feedback and push updates to the PR
+
+### Releases
+
+Releases are automated on pushes to `main` with semantic-release and GoReleaser.
+
+Required secrets:
+
+- `GITHUB_TOKEN` (provided automatically by GitHub Actions)
+
+Optional secrets (only if configured in `.goreleaser.yml`):
+
+- `GORELEASER_KEY` for GoReleaser Pro
+- `TAP_GITHUB_TOKEN` for Homebrew tap publishing


### PR DESCRIPTION
## Summary
- automate releases on main with semantic-release for versioning
- publish Go binaries with GoReleaser after a release is created
- document required release secrets for GitHub Actions

## Why
Automated releases keep versioning consistent with conventional commits and ensure binaries are published from a single, repeatable workflow.